### PR TITLE
Fix artifact naming issue in deployment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.project
+.classpath
+.settings/
+.vscode/
+
 target/
 .m2/
 .mvn/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
 deploy:
   provider: script
   script: cd $TRAVIS_BUILD_DIR && bash build-resources/travis-release.sh
+  skip_cleanup: true
   on:
     tags: true
     branch: master

--- a/bindings-generator/pom.xml
+++ b/bindings-generator/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>vcd-bindings-generator</artifactId>
     <parent>
         <groupId>com.vmware.vcloud</groupId>
-        <artifactId>api-tooling-parent</artifactId>
+        <artifactId>vcd-api-tooling-parent</artifactId>
         <version>0.9.0</version>
     </parent>
     <name>${project.artifactId} :: Bindings generation utility</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.vmware.vcloud</groupId>
-  <artifactId>api-tooling-parent</artifactId>
+  <artifactId>vcd-api-tooling-parent</artifactId>
   <version>0.9.0</version>
   <packaging>pom</packaging>
   <name>${project.artifactId} :: vCloud Director REST API tooling parent</name>

--- a/vcd-bindings-maven-plugin/pom.xml
+++ b/vcd-bindings-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     <packaging>maven-plugin</packaging>
     <parent>
         <groupId>com.vmware.vcloud</groupId>
-        <artifactId>api-tooling-parent</artifactId>
+        <artifactId>vcd-api-tooling-parent</artifactId>
         <version>0.9.0</version>
     </parent>
     <name>${project.artifactId} :: Maven plugin wrapper for bindings generation utility</name>

--- a/vcd-xjc-plugins/pom.xml
+++ b/vcd-xjc-plugins/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>vcd-xjc-plugins</artifactId>
   <parent>
     <groupId>com.vmware.vcloud</groupId>
-    <artifactId>api-tooling-parent</artifactId>
+    <artifactId>vcd-api-tooling-parent</artifactId>
     <version>0.9.0</version>
   </parent>
   <packaging>jar</packaging>


### PR DESCRIPTION
This change prepends vcd- to the parent project just like all the other
projects. It also adds some additional Git ignores for a dev environment
and uses the Travis install artifacts for deployment instead of
rebuilding.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-api-tools/3)
<!-- Reviewable:end -->
