### PR TITLE
Attempt to fix Travis multi-module staging issue.

### DIFF
--- a/build-resources/travis-release.sh
+++ b/build-resources/travis-release.sh
@@ -21,4 +21,4 @@ else
 fi
 
 # Push to Sonatype/Maven Central
-mvn --settings build-resources/travis-settings.xml deploy
+mvn -Prelease --settings build-resources/travis-settings.xml deploy

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
           <plugins>
             <!--
              Maven Release Plugin
-             To release this project, follow the isntructions in RELEASING.md
+             To release this project, follow the instructions in RELEASING.md
             -->
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
@@ -265,7 +265,8 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <stagingProfileId>863e26d72b942f</stagingProfileId>
+              <stagingProfileRepository>vcd-api-tooling-parent-${project.version}</stagingProfileRepository>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
The issue https://github.com/travis-ci/travis-ci/issues/9555 turns out to
be a bit of a kick in the teeth to having a reasonable staging area in
Sonatype. One of the recommendations is to replace Maven's deploy plugin
with the Nexus staging plugin and force use of specific staging profiles
and repositories.

This change attempts to do that by using the singular staging profile and
tying a staging repository name to the GitHub repository name and release
version.

If this doesn't work we may have to reconsider CI options.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-api-tools/4)
<!-- Reviewable:end -->
