### PR TITLE
 Fix issues in Typescript barrel generation.

### DIFF
--- a/bindings-generator/pom.xml
+++ b/bindings-generator/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.vmware.vcloud</groupId>
         <artifactId>vcd-api-tooling-parent</artifactId>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
     </parent>
     <name>${project.artifactId} :: Bindings generation utility</name>
     <description>Provides custom API bindings generation beyond what can be accomplished with xjc and OpenAPI</description>

--- a/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/BindingsGenerator.java
+++ b/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/BindingsGenerator.java
@@ -243,7 +243,7 @@ public class BindingsGenerator {
 
         Map<Path, List<String>> barrels = new HashMap<>();
         try (Stream<Path> files = Files.walk(outputDir.toPath())) {
-            files.forEach(f -> {
+            files.filter(f -> !"index.ts".equals(f.getFileName().toString())).forEach(f -> {
                 if (Files.isDirectory(f)) {
                     barrels.putIfAbsent(outputDir.toPath().relativize(f), new ArrayList<>());
                 }

--- a/bindings-generator/src/main/resources/typescript/index.ts.vm
+++ b/bindings-generator/src/main/resources/typescript/index.ts.vm
@@ -3,7 +3,7 @@
  */
 #foreach(${import} in ${imports})
 #if(${import.endsWith("/")})
-import * as ${_formatter.chop(${import})} from './${import}/index';
+import * as ${_formatter.chop(${import})} from './${import}index';
 export {
     ${_formatter.chop(${import})}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.vmware.vcloud</groupId>
   <artifactId>vcd-api-tooling-parent</artifactId>
-  <version>0.9.1</version>
+  <version>0.9.2</version>
   <packaging>pom</packaging>
   <name>${project.artifactId} :: vCloud Director REST API tooling parent</name>
   <description>Parent project housing tools and utilities to process vCloud Director APIs and build bindings</description>

--- a/vcd-bindings-maven-plugin/pom.xml
+++ b/vcd-bindings-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.vmware.vcloud</groupId>
         <artifactId>vcd-api-tooling-parent</artifactId>
-        <version>0.9.1</version>
+        <version>0.9.2</version>
     </parent>
     <name>${project.artifactId} :: Maven plugin wrapper for bindings generation utility</name>
 

--- a/vcd-xjc-plugins/pom.xml
+++ b/vcd-xjc-plugins/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>vcd-api-tooling-parent</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
   </parent>
   <packaging>jar</packaging>
   <name>${project.artifactId} :: Custom plugins for XML to Java Compilation</name>


### PR DESCRIPTION
If the Maven compile goal was executed multiple times without a clean,
then the construction of the index.ts file would include a reference to
itself for re-export. This caused a circular reexport issue in certain
consumers of the @vcd/bindings package.

The generation process has been updated to ignore an existing index.ts,
and also to not add an extra slash to folder re-exports.

Testing done:
Compiled new bindings generator and installed it to local Maven repo.
Rebuilt the vcd-api-schemas repo with new libraries, verified successful
completion, and verified the new index.ts output with manual inspection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-api-tools/9)
<!-- Reviewable:end -->
