### PR TITLE
Set spring to proper version for java 8 and bumped cxf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <cxf.version>3.4.10</cxf.version>
-        <spring.version>6.0.14</spring.version>
+        <cxf.version>3.5.8</cxf.version>
+        <spring.version>5.3.33</spring.version>
         <swagger.version>1.6.6</swagger.version>
     </properties>
     <build>


### PR DESCRIPTION
Spring was improperly bumped to 6.x which only works with java 17+. I
have reset spring back to 5.3.33 which is the latest version compatible
with java 8.

I also bumped the version of cxf to the latest version of 3.5.x.

Signed-off-by: Thomas Grimshaw <grimshawthom@vmware.com>